### PR TITLE
Use choose to select build location

### DIFF
--- a/StardewModdingAPI/StardewModdingAPI.csproj
+++ b/StardewModdingAPI/StardewModdingAPI.csproj
@@ -36,6 +36,18 @@
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <TargetFrameworkProfile />
   </PropertyGroup>
+  <Choose>
+	<When Condition="'$(SteamInstallPath)' != ''">
+	  <PropertyGroup>
+		<SteamPath>$(SteamInstallPath)</SteamPath>
+      </PropertyGroup>
+	</When>
+  <Otherwise>
+	<PropertyGroup>
+	  <SteamPath>..\..\..\..\Games\SteamLibrary</SteamPath>
+    </PropertyGroup>
+	</Otherwise>
+  </Choose>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>x86</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
@@ -80,7 +92,7 @@
     <Reference Include="Microsoft.Xna.Framework.Xact, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553, processorArchitecture=x86" />
     <Reference Include="Stardew Valley, Version=1.0.5905.5747, Culture=neutral, processorArchitecture=x86">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\Games\SteamLibrary\steamapps\common\Stardew Valley\Stardew Valley.exe</HintPath>
+      <HintPath>$(SteamPath)\steamapps\common\Stardew Valley\Stardew Valley.exe</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -93,7 +105,7 @@
     <Reference Include="System.Xml" />
     <Reference Include="xTile, Version=2.0.4.0, Culture=neutral, processorArchitecture=x86">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\Games\SteamLibrary\steamapps\common\Stardew Valley\xTile.dll</HintPath>
+      <HintPath>$(SteamPath)\steamapps\common\Stardew Valley\xTile.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/TrainerMod/TrainerMod.csproj
+++ b/TrainerMod/TrainerMod.csproj
@@ -33,6 +33,18 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <Choose>
+	<When Condition="'$(SteamInstallPath)' != ''">
+	  <PropertyGroup>
+		<SteamPath>$(SteamInstallPath)</SteamPath>
+      </PropertyGroup>
+	</When>
+  <Otherwise>
+	<PropertyGroup>
+	  <SteamPath>..\..\..\..\Games\SteamLibrary</SteamPath>
+    </PropertyGroup>
+	</Otherwise>
+  </Choose>
   <ItemGroup>
     <Reference Include="Microsoft.Xna.Framework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553, processorArchitecture=x86">
       <Private>False</Private>
@@ -41,7 +53,7 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="Stardew Valley">
-      <HintPath>..\..\..\..\Games\SteamLibrary\steamapps\common\Stardew Valley\Stardew Valley.exe</HintPath>
+      <HintPath>$(SteamPath)\steamapps\common\Stardew Valley\Stardew Valley.exe</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
@@ -53,7 +65,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="xTile">
-      <HintPath>..\..\..\..\Games\SteamLibrary\steamapps\common\Stardew Valley\xTile.dll</HintPath>
+      <HintPath>$(SteamPath)\steamapps\common\Stardew Valley\xTile.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>


### PR DESCRIPTION
Hey, saw we had issues with the env variable. I added a choose so that the projects automatically select whether to use the relative path or the env variable.

 - Con of Env Variable: Not everyone has the variable set, so might be difficult to set up build.
 - Con of relative: Have to have the repo in a very specific location for build to be successful, which is not always the case.

The MSBuild code below checks whether env variable is set - if it isn't, it uses the relative path. Let me know whether you have concerns.