### PR TITLE
Perf improvements

### DIFF
--- a/StardewModdingAPI/Extensions.cs
+++ b/StardewModdingAPI/Extensions.cs
@@ -53,12 +53,12 @@ namespace StardewModdingAPI
         
         public static int GetHash(this IEnumerable enumerable)
         {
-            string s = string.Empty;
+            int hash = 0;
             foreach (var v in enumerable)
             {
-                s += v.GetHashCode().ToString();
+                hash ^= v.GetHashCode();
             }
-            return s.GetHashCode();
+            return hash;
         } 
     }
 }

--- a/StardewModdingAPI/Inheritance/SGame.cs
+++ b/StardewModdingAPI/Inheritance/SGame.cs
@@ -465,12 +465,13 @@ namespace StardewModdingAPI.Inheritance
             {
                 Events.PlayerEvents.InvokeInventoryChanged(player.items, changedItems);
                 PreviousItems = player.items.Where(n => n != null).ToDictionary(n => n, n => n.Stack);
-            }            
+            }
 
-            if(currentLocation != null && PreviousLocationObjects != currentLocation.objects.GetHash())
+            var objectHash = currentLocation?.objects?.GetHash();
+            if(objectHash != null && PreviousLocationObjects != objectHash)
             {
                 Events.LocationEvents.InvokeOnNewLocationObject(currentLocation.objects);
-                PreviousLocationObjects = currentLocation.objects.GetHash();
+                PreviousLocationObjects = objectHash ?? -1;
             }
 
             if (timeOfDay != PreviousTimeOfDay)


### PR DESCRIPTION
Should help with #12 

 - The original '+=' of the GetHash method was taking ~10% of CPU usage for the game. This should improve performance considerably.

 - The next largest CPU usage we care about is the 'GetHash' method that gets called very often. Pulling the objects.GetHash() out will reduce hits on the method.