### PR TITLE
Correct fix for https://github.com/ClxS/SMAPI/issues/74

### DIFF
--- a/StardewModdingAPI/Inheritance/SGame.cs
+++ b/StardewModdingAPI/Inheritance/SGame.cs
@@ -1252,10 +1252,7 @@ namespace StardewModdingAPI.Inheritance
                 }
                 
                 GraphicsEvents.InvokeOnPostRenderEvent(null, EventArgs.Empty);
-                spriteBatch.End();
-
-                GraphicsEvents.InvokeDrawTick();
-                GraphicsEvents.InvokeDrawInRenderTargetTick();
+                spriteBatch.End();                
 
                 if (!ZoomLevelIsOne)
                 {
@@ -1265,6 +1262,9 @@ namespace StardewModdingAPI.Inheritance
                     spriteBatch.Draw(Screen, Vector2.Zero, Screen.Bounds, Color.White, 0f, Vector2.Zero, options.zoomLevel, SpriteEffects.None, 1f);
                     spriteBatch.End();
                 }
+
+                GraphicsEvents.InvokeDrawTick();
+                GraphicsEvents.InvokeDrawInRenderTargetTick();
 
                 #endregion
             }

--- a/StardewModdingAPI/Inheritance/SGame.cs
+++ b/StardewModdingAPI/Inheritance/SGame.cs
@@ -1312,10 +1312,7 @@ namespace StardewModdingAPI.Inheritance
 
                     GraphicsEvents.InvokeOnPostRenderEvent(null, EventArgs.Empty);
                     spriteBatch.End();
-
-                    GraphicsEvents.InvokeDrawTick();
-                    GraphicsEvents.InvokeDrawInRenderTargetTick();
-
+                    
                     if (!ZoomLevelIsOne)
                     {
                         GraphicsDevice.SetRenderTarget(null);
@@ -1324,6 +1321,9 @@ namespace StardewModdingAPI.Inheritance
                         spriteBatch.Draw(Screen, Vector2.Zero, Screen.Bounds, Color.White, 0f, Vector2.Zero, options.zoomLevel, SpriteEffects.None, 1f);
                         spriteBatch.End();
                     }
+
+                    GraphicsEvents.InvokeDrawTick();
+                    GraphicsEvents.InvokeDrawInRenderTargetTick();
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
The previous fix attempt DOES stop with the exceptions.

But legacy mods still doesn't work (they don't render anything at all).

This should fix it.

Also, on my test I had to uncomment "base.Draw()", when it was commented the screen rendered black on the mines, so it was impossible to test with the healthbar mods.