### PR TITLE
made gui render events work when background is on

### DIFF
--- a/StardewModdingAPI/Inheritance/SGame.cs
+++ b/StardewModdingAPI/Inheritance/SGame.cs
@@ -867,7 +867,9 @@ namespace StardewModdingAPI.Inheritance
                     {
                         spriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.PointClamp, null, null);
                         activeClickableMenu.drawBackground(spriteBatch);
+                        GraphicsEvents.InvokeOnPreRenderGuiEvent(null, EventArgs.Empty);
                         activeClickableMenu.draw(spriteBatch);
+                        GraphicsEvents.InvokeOnPostRenderGuiEvent(null, EventArgs.Empty);
                         spriteBatch.End();
                         if (!ZoomLevelIsOne)
                         {


### PR DESCRIPTION
with the changes made to SMAPI this morning my mods all work.

Unless the player enabled the option in their game to put backgrounds on the menus... this fixes it, it was just a missing pair of invokes.